### PR TITLE
Catch ipfs error, and Readme edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,30 +39,38 @@ If you're new to the space, it may be helpful to first familiarize yourself with
 
 ## Install and run the demo app
 
-1. Download Ethereum test-rpc and truffle:
-
-    `npm i -g ethereumjs-testrpc`
-
-    `npm install -g truffle`
-
-2. `git clone https://github.com/0riginOrg/0rigin`
-
-3. `truffle compile`
-
-4. `truffle migrate`
-
-5. `npm install`
-
-6. `npm run start`
-
-7. In another terminal tab:
-
-    `testrpc`
-
-8. In [Metamask](https://metamask.io/), configure RPC to be private network (localhost 8545) and import the private key for one of your test wallets (should show roughly 100 Eth) - *DO NOT GET YOUR MAIN NET WALLET MIXED UP*
-This needs to be done every single time a new testrpc instance is run.
-* After awhile, your Metamask will be cluttered with invalid addresses. [Here is how you clear it](https://ethereum.stackexchange.com/questions/21422/how-to-remove-unused-test-accounts-from-metamask/21468)
-* While we dev, I would actually not recommend having real Eth in a Main Net wallet so we can dump it whenever
+1. Download Ethereum [test-rpc](https://github.com/ethereumjs/testrpc) and [truffle](http://truffleframework.com/):
+```
+npm i -g ethereumjs-testrpc
+npm install -g truffle
+```
+2. Clone 0rigin:
+```
+git clone https://github.com/0riginOrg/0rigin
+cd 0rigin
+```
+3. Compile contracts:
+```
+truffle compile
+truffle migrate
+````
+4. Start 0rigin node application. 
+```
+npm install
+npm run start
+````
+5. A browser will open to http://localhost:3000
+![0rigin-homepage](https://user-images.githubusercontent.com/673455/30517963-0603f3d8-9b2d-11e7-9ef4-327b747695eb.png)
+6. In another terminal tab:
+```
+testrpc
+```
+  This will output credentials for several test wallets with 100 Eth.
+  
+7. In [Metamask](https://metamask.io/), configure RPC to be private network (localhost 8545) and import the private key for one of your test wallets from previous step. **DO NOT GET YOUR MAIN NET WALLET MIXED UP**.
+  * This needs to be done every single time a new testrpc instance is run.
+  * After awhile, your Metamask will be cluttered with invalid addresses. [Here is how you clear it](https://ethereum.stackexchange.com/questions/21422/how-to-remove-unused-test-accounts-from-metamask/21468)
+  * While we dev, I would actually not recommend having real Eth in a Main Net wallet so we can dump it whenever
 
 ## Get involved
 

--- a/src/components/demo-step-2.js
+++ b/src/components/demo-step-2.js
@@ -8,6 +8,9 @@ class DemoStep2 extends Component {
     ipfsService.submitListing(listingData)
     .then((ipfsHash) => {
       onSubmitToIpfs(ipfsHash)
+    })
+    .catch((error) => {
+      alert(error)
     });
   }
 
@@ -16,25 +19,25 @@ class DemoStep2 extends Component {
       <section className="step">
         <h4>Post your listing to the decentralized web</h4>
         <p>
-          When creating your listing, we store your data as JSON.  
+          When creating your listing, we store your data as JSON.
         </p>
         <p>
           Cryptographically sign your listing using <a href='http://www.keybase.io'>KeyBase</a> to verify your identity on services like Facebook and Twitter with publicly auditable proofs.
         </p>
         <pre>{JSON.stringify(this.props.listingJson, null, 2)}</pre>
         <p>
-          In traditional commerce, this JSON would be sent to 
-          a centralized business like Craigslist, Airbnb, or eBay. The data 
+          In traditional commerce, this JSON would be sent to
+          a centralized business like Craigslist, Airbnb, or eBay. The data
           would then be stored in their databases.
         </p>
         <p>
-          Because we want to build decentralized, trustless commerce, we need to 
+          Because we want to build decentralized, trustless commerce, we need to
           store your data in a distributed data store that isn't owned by anyone.
         </p>
         <p>
           Enter the much-heralded IPFS (Interplanetary File System). We post your
-          data to hundreds of distributed nodes on the IPFS network. This ensures 
-          that your listing is always available, and more importantly, is not subject 
+          data to hundreds of distributed nodes on the IPFS network. This ensures
+          that your listing is always available, and more importantly, is not subject
           to the whims and arbitrary policies of any centralized business or government.
         </p>
         <div className="btn-wrapper">

--- a/src/services/ipfs-service.js
+++ b/src/services/ipfs-service.js
@@ -10,7 +10,7 @@ class IpfsService {
     }
 
     this.ipfs = ipfsAPI(DEFAULT_GATEWAY, '5001', {protocol: 'http'})
-    this.ipfs.swarm.peers(function(error, response) { 
+    this.ipfs.swarm.peers(function(error, response) {
       if (error) {
         console.log("Can't connect to the IPFS Gateway.")
         console.error(error)
@@ -21,7 +21,7 @@ class IpfsService {
 
     IpfsService.instance = this
   }
-  
+
   submitListing(formListing) {
     return new Promise((resolve, reject) => {
       const file = {
@@ -30,6 +30,12 @@ class IpfsService {
       }
 
       this.ipfs.files.add([file], (error, response) => {
+        if (error) {
+          console.log("Can't connect to the IPFS Gateway.")
+          console.error(error)
+          reject('Can\'t connect to the IPFS Gateway. Failure to submit listing to Ipfs')
+          return
+        }
         const file = response[0]
         const ipfsListing = file.hash
 


### PR DESCRIPTION
Note: Apologies for my editor creating "edits" by removing trailing spaces. I can re-submit without those if desired. 

- A few updates to the readme based on my experience getting it running on MacOS. 

- Added a catch() to handle ipfs failure when the gateway is down. For now it just displays generic ugly javascript alert() box. Slightly better than doing nothing. 